### PR TITLE
Honor 'minItems:0' in the items generator.

### DIFF
--- a/lib/generators/items.js
+++ b/lib/generators/items.js
@@ -8,6 +8,10 @@ module.exports = function items(schema, fn) {
             return fn.resolve(subSchema);
         })
     } else {
-        fn.data = [fn.resolve(schema.items)];
+        if (schema.minItems === 0) {
+            fn.data = [];
+        } else {
+            fn.data = [fn.resolve(schema.items)];
+        }
     }
 };


### PR DESCRIPTION
If an array item has 'minItems:0' then the items generator should return an empty array.